### PR TITLE
Fix for compiling bindings for PyTorch 1.5

### DIFF
--- a/pytorch_binding/src/pychain.cc
+++ b/pytorch_binding/src/pychain.cc
@@ -20,7 +20,7 @@
 #include "chain-computation.h"
 #include "base.h"
 
-#define CHECK_CONTIGUOUS(x) AT_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 
 std::vector<torch::Tensor> ForwardBackward(
     torch::Tensor forward_transitions,


### PR DESCRIPTION
Minor fix that makes the pytorch bindings compile with pytorch 1.5.0. Tested with your [WSJ example](https://github.com/YiwenShaoStephen/pychain_example/tree/new/examples/wsj).