### PR TITLE
log-domain and copy specific pdfs

### DIFF
--- a/openfst_binding/src/fstext.cc
+++ b/openfst_binding/src/fstext.cc
@@ -16,7 +16,7 @@ namespace fst {
   }
 }
 
-std::vector<torch::Tensor> FstToTensor(const fst::StdVectorFst &fst) {
+std::vector<torch::Tensor> FstToTensor(const fst::StdVectorFst &fst, bool log_domain=false) {
   struct GraphTransition {
     int in_state;
     int out_state;
@@ -28,7 +28,7 @@ std::vector<torch::Tensor> FstToTensor(const fst::StdVectorFst &fst) {
   };
 
   int num_states = fst.NumStates();
-  
+
   std::vector<std::vector<GraphTransition> > transitions_out_tup(num_states);
   std::vector<std::vector<GraphTransition> > transitions_in_tup(num_states);
   std::vector<float> final_probs(num_states);
@@ -39,9 +39,9 @@ std::vector<torch::Tensor> FstToTensor(const fst::StdVectorFst &fst) {
          aiter.Next()) {
       const fst::StdArc &arc = aiter.Value();
       int pdf_id = arc.ilabel - 1;
-      assert(pdf_id >= 0 && pdf_id < num_pdfs);
-      transitions_out_tup[s].emplace_back(s, arc.nextstate, pdf_id, -arc.weight.Value()); 
-      transitions_in_tup[arc.nextstate].emplace_back(s, arc.nextstate, pdf_id, -arc.weight.Value()); 
+      // assert(pdf_id >= 0 && pdf_id < num_pdfs);
+      transitions_out_tup[s].emplace_back(s, arc.nextstate, pdf_id, -arc.weight.Value());
+      transitions_in_tup[arc.nextstate].emplace_back(s, arc.nextstate, pdf_id, -arc.weight.Value());
     }
   }
 
@@ -50,7 +50,7 @@ std::vector<torch::Tensor> FstToTensor(const fst::StdVectorFst &fst) {
   std::vector<float> forward_log_probs;
   for (int s = 0; s < num_states; s++) {
     forward_transition_indices[2*s] = static_cast<int32>(forward_transitions.size()) / 3;
-    for (auto it = transitions_out_tup[s].begin(); 
+    for (auto it = transitions_out_tup[s].begin();
          it != transitions_out_tup[s].end(); ++it) {
       auto& transition = *it;
       forward_transitions.push_back(transition.in_state);
@@ -66,7 +66,7 @@ std::vector<torch::Tensor> FstToTensor(const fst::StdVectorFst &fst) {
   std::vector<float> backward_log_probs;
   for (int s = 0; s < num_states; s++) {
     backward_transition_indices[2*s] = static_cast<int32>(backward_transitions.size()) / 3;
-    for (auto it = transitions_in_tup[s].begin(); 
+    for (auto it = transitions_in_tup[s].begin();
          it != transitions_in_tup[s].end(); ++it) {
       auto& transition = *it;
       backward_transitions.push_back(transition.in_state);
@@ -86,7 +86,8 @@ std::vector<torch::Tensor> FstToTensor(const fst::StdVectorFst &fst) {
 
   torch::Tensor forward_transition_probs_tensor = torch::empty({num_transitions}, torch::kFloat);
   forward_transition_probs_tensor.copy_(torch::from_blob(forward_log_probs.data(), {num_transitions}, torch::kFloat));
-  forward_transition_probs_tensor.exp_();
+  if (!log_domain)
+    forward_transition_probs_tensor.exp_();
 
   torch::Tensor backward_transitions_tensor = torch::empty({num_transitions, 3}, torch::kInt);
   backward_transitions_tensor.copy_(
@@ -97,11 +98,14 @@ std::vector<torch::Tensor> FstToTensor(const fst::StdVectorFst &fst) {
 
   torch::Tensor backward_transition_probs_tensor = torch::empty({num_transitions}, torch::kFloat);
   backward_transition_probs_tensor.copy_(torch::from_blob(backward_log_probs.data(), {num_transitions}, torch::kFloat));
-  backward_transition_probs_tensor.exp_();
+  if (!log_domain)
+    backward_transition_probs_tensor.exp_();
 
   torch::Tensor final_probs_tensor = torch::empty({num_states}, torch::kFloat);
   final_probs_tensor.copy_(torch::from_blob(final_probs.data(), {num_states}, torch::kFloat));
-  final_probs_tensor.exp_();
+  if (!log_domain)
+    final_probs_tensor.exp_();
+
   return {forward_transitions_tensor,
       forward_transition_probs_tensor,
       forward_transition_indices_tensor,
@@ -126,7 +130,7 @@ torch::Tensor SetLeakyProbs(const fst::StdVectorFst &fst) {
   // have transition probabilities.
   torch::Tensor normalizing_factor = torch::zeros(num_states, torch::kDouble);
   auto nf_a = normalizing_factor.accessor<double, 1>();
- 
+
   for (int32 s = 0; s < num_states; s++) {
     double tot_prob = exp(-fst.Final(s).Value());
     for (fst::ArcIterator<fst::StdVectorFst> aiter(fst, s); !aiter.Done();

--- a/pychain/graph.py
+++ b/pychain/graph.py
@@ -21,21 +21,64 @@ import simplefst
 
 class ChainGraph(object):
 
-    def __init__(self, fst, leaky_mode='uniform'):
+    def __init__(
+        self,
+        fst,
+        leaky_mode='uniform',
+        initial_mode="fst",
+        final_mode="fst",
+        log_domain=False,
+        map_pdfs=False,
+    ):
         self.num_states = fst.num_states()
-        assert(leaky_mode in ['uniform', 'transition'])
+        assert (leaky_mode in ['uniform', 'transition', 'hmm'])
+        assert (final_mode in ['fst', 'one'])
+        assert (initial_mode in ['fst', 'leaky'])
         self.leaky_mode = leaky_mode
-        (self.forward_transitions,
-         self.forward_transition_probs,
-         self.forward_transition_indices,
-         self.backward_transitions,
-         self.backward_transition_probs,
-         self.backward_transition_indices,
-         self.final_probs) = simplefst.StdVectorFst.fst_to_tensor(fst)
+        self.log_domain = log_domain
+        (
+            self.forward_transitions,
+            self.forward_transition_probs,
+            self.forward_transition_indices,
+            self.backward_transitions,
+            self.backward_transition_probs,
+            self.backward_transition_indices,
+            self.final_probs,
+        ) = simplefst.StdVectorFst.fst_to_tensor(fst, log_domain)
+
+        self.index_to_pdf = None
+        self.num_uniq_pdfs = -1
+        if map_pdfs:
+            backward_pdf_ids = self.backward_transitions.narrow(1, 2, 1).squeeze(1)  # |E|
+            self.index_to_pdf, backward_pdf_ids_mapped = torch.unique(
+                backward_pdf_ids, sorted=True, return_inverse=True
+            )
+            backward_pdf_ids.copy_(backward_pdf_ids_mapped)
+
+            self.num_uniq_pdfs = self.index_to_pdf.size(0)
+
+            max_pdf_id = self.index_to_pdf[-1]
+            pdf_to_index = torch.empty(
+                max_pdf_id + 1, dtype=torch.int32
+            ).fill_(-2)  # dummy
+            for i in range(self.num_uniq_pdfs):
+                pdf_to_index[self.index_to_pdf[i]] = i
+
+            forward_pdf_ids = self.forward_transitions.narrow(1, 2, 1).squeeze(1)  # |E|
+            forward_pdf_ids_mapped = pdf_to_index[forward_pdf_ids.long()]
+
+            # Make sure all pdfs are mapped
+            assert torch.sum(forward_pdf_ids_mapped == -2) == 0
+            forward_pdf_ids.copy_(forward_pdf_ids_mapped)
+
+            self.index_to_pdf = self.index_to_pdf.long()
 
         self.num_transitions = self.forward_transitions.size(0)
         self.is_empty = (self.num_transitions == 0)
         self.start_state = simplefst.StdVectorFst.start_state(fst)
+
+        self.initial_probs = torch.zeros(self.num_states)
+
         if not self.is_empty:
             if leaky_mode == 'transition':
                 start, end = self.forward_transition_indices[self.start_state]
@@ -43,9 +86,19 @@ class ChainGraph(object):
                 self.leaky_probs = torch.zeros(self.num_states)
                 self.leaky_probs[entries] = self.forward_transition_probs[start:end]
                 self.leaky_probs = self.leaky_probs / self.leaky_probs.sum()
-            else:
+            elif leaky_mode == "uniform":
                 self.leaky_probs = torch.ones(
                     self.num_states) / self.num_states
+            elif leaky_mode == "hmm":
+                self.leaky_probs = openfst_binding.StdVectorFst.set_leaky_probs(fst)
+
+            if initial_mode == "fst":
+                self.initial_probs[self.start_state] = 1.0
+            else:
+                self.initial_probs.copy_(self.leaky_probs)
+
+            if final_mode == "one":
+                self.final_probs.fill_(1.0)
 
 
 class ChainGraphBatch(object):
@@ -88,11 +141,18 @@ class ChainGraphBatch(object):
         self.num_states = graph.num_states
         self.final_probs = graph.final_probs.repeat(B, 1)
         self.leaky_probs = graph.leaky_probs.repeat(B, 1)
+        self.initial_probs = graph.initial_probs.repeat(B, 1)
         self.start_state = graph.start_state * torch.ones(B, dtype=torch.long)
+        self.log_domain = graph.log_domain
+        self.index_to_pdf = None
+        if graph.index_to_pdf is not None:
+            self.index_to_pdf = graph.index_to_pdf.repeat(B, 1)
+        self.num_uniq_pdfs = graph.num_uniq_pdfs
 
     def initialized_by_list(self, graphs, max_num_transitions, max_num_states):
         transition_type = graphs[0].forward_transitions.dtype
         probs_type = graphs[0].forward_transition_probs.dtype
+        self.log_domain = graphs[0].log_domain
         self.num_states = max_num_states
         self.num_transitions = max_num_transitions
         self.forward_transitions = torch.zeros(
@@ -109,15 +169,27 @@ class ChainGraphBatch(object):
             self.batch_size, max_num_transitions, dtype=probs_type)
         self.leaky_probs = torch.zeros(
             self.batch_size, max_num_states, dtype=probs_type)
+        self.initial_probs = torch.zeros(
+            self.batch_size, max_num_states, dtype=probs_type)
         self.final_probs = torch.zeros(
-            self.batch_size, max_num_states, dtype=probs_type,
-        )
+            self.batch_size, max_num_states, dtype=probs_type)
         self.start_state = torch.zeros(self.batch_size, dtype=torch.long)
+
+        self.index_to_pdf = None
+        self.num_uniq_pdfs = -1
+        if graphs[0].index_to_pdf is not None:
+            self.num_uniq_pdfs = max((g.num_uniq_pdfs for g in graphs))
+            self.index_to_pdf = torch.zeros(
+                self.batch_size,
+                self.num_uniq_pdfs,
+                dtype=graphs[0].index_to_pdf.dtype,
+            )
 
         for i in range(len(graphs)):
             graph = graphs[i]
             num_transitions = graph.num_transitions
             num_states = graph.num_states
+            num_uniq_pdfs = graph.num_uniq_pdfs
             self.forward_transitions[i, :num_transitions, :].copy_(
                 graph.forward_transitions)
             self.forward_transition_indices[i, :num_states, :].copy_(
@@ -131,8 +203,11 @@ class ChainGraphBatch(object):
             self.backward_transition_probs[i, :num_transitions].copy_(
                 graph.backward_transition_probs)
             self.leaky_probs[i, :num_states].copy_(graph.leaky_probs)
+            self.initial_probs[i, :num_states].copy_(graph.initial_probs)
             self.final_probs[i, :num_states].copy_(graph.final_probs)
             self.start_state[i] = graph.start_state
+            if self.index_to_pdf is not None:
+                self.index_to_pdf[i, :num_uniq_pdfs].copy_(graph.index_to_pdf)
 
     def reorder(self, new_order):
         self.forward_transitions = self.forward_transitions.index_select(
@@ -148,5 +223,8 @@ class ChainGraphBatch(object):
         self.backward_transition_probs = self.backward_transition_probs.index_select(
             0, new_order)
         self.leaky_probs = self.leaky_probs.index_select(0, new_order)
+        self.initial_probs = self.initial_probs.index_select(0, new_order)
         self.final_probs = self.final_probs.index_select(0, new_order)
         self.start_state = self.start_state.index_select(0, new_order)
+        if self.index_to_pdf is not None:
+            self.index_to_pdf = self.index_to_pdf.index_select(0, new_order)

--- a/pychain/loss.py
+++ b/pychain/loss.py
@@ -14,10 +14,164 @@
 # See the Apache 2 License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import torch
 import torch.nn as nn
 from pychain.graph import ChainGraphBatch
 import pychain_C
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+class ChainLossFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        input,
+        input_lengths,
+        num_graphs,
+        den_graph,
+        num_leaky_coefficient,
+        den_leaky_coefficient
+    ):
+        exp_input = input.clamp(-30, 30).exp()
+        B = input.size(0)
+        T = input.size(1)
+        if B != num_graphs.batch_size:
+            raise ValueError("input batch size {0} does not equal to graph batch size {1}"
+                             .format(B, num_graphs.batch_size))
+        packed_data = torch.nn.utils.rnn.pack_padded_sequence(
+            input, input_lengths, batch_first=True)
+        batch_sizes = packed_data.batch_sizes
+        input_lengths = input_lengths.cpu()
+
+        den_graphs = ChainGraphBatch(den_graph, B)
+
+        den_objf, input_grad, denominator_ok = pychain_C.forward_backward(
+            den_graphs.forward_transitions,
+            den_graphs.forward_transition_indices,
+            den_graphs.forward_transition_probs,
+            den_graphs.backward_transitions,
+            den_graphs.backward_transition_indices,
+            den_graphs.backward_transition_probs,
+            den_graphs.leaky_probs,
+            den_graphs.initial_probs,
+            den_graphs.final_probs,
+            den_graphs.start_state,
+            exp_input,
+            batch_sizes,
+            input_lengths,
+            den_graphs.num_states,
+            den_leaky_coefficient,
+        )
+
+        den_mask = input_grad.argmax(axis=2)
+
+        index_to_pdf = None
+        if num_graphs.index_to_pdf is not None:
+            index_to_pdf = num_graphs.index_to_pdf.to(device=input.device)
+
+        if num_graphs.log_domain:
+            if index_to_pdf is not None:
+                # index_to_pdf B x U -> B x 1 x U -> B x T x U
+                log_probs = torch.gather(
+                    input,
+                    2,
+                    index_to_pdf.unsqueeze(1).expand((-1, T, -1)),
+                )  # B x T x U
+
+            num_objf, log_probs_grad, numerator_ok = pychain_C.numerator_fb(
+                num_graphs.forward_transitions,
+                num_graphs.forward_transition_indices,
+                num_graphs.forward_transition_probs,
+                num_graphs.backward_transitions,
+                num_graphs.backward_transition_indices,
+                num_graphs.backward_transition_probs,
+                num_graphs.final_probs,
+                num_graphs.start_state,
+                log_probs.to(device='cpu')
+                if index_to_pdf is not None
+                else input.to(device='cpu'),
+                batch_sizes,
+                input_lengths,
+                num_graphs.num_states,
+            )
+            num_objf = num_objf.to(device=input.device)
+        else:
+            num_objf, log_probs_grad, numerator_ok = pychain_C.forward_backward(
+                num_graphs.forward_transitions,
+                num_graphs.forward_transition_indices,
+                num_graphs.forward_transition_probs,
+                num_graphs.backward_transitions,
+                num_graphs.backward_transition_indices,
+                num_graphs.backward_transition_probs,
+                num_graphs.leaky_probs,
+                num_graphs.initial_probs,
+                num_graphs.final_probs,
+                num_graphs.start_state,
+                exp_input,
+                batch_sizes,
+                input_lengths,
+                num_graphs.num_states,
+                num_leaky_coefficient,
+            )
+
+        numerator_ok = numerator_ok.item()
+        denominator_ok = denominator_ok.item()
+
+        loss = -num_objf + den_objf
+
+        default_loss = 10
+        if ((loss - loss) != 0 or not denominator_ok or not numerator_ok):
+            input_grad = torch.zeros_like(input)
+            logger.warn(
+                f"Loss is {loss}) and denominator computation "
+                f"(if done) returned {denominator_ok} "
+                f"and numerator computation returned {numerator_ok} "
+                f", setting loss to {default_loss} per frame"
+            )
+            loss = torch.zeros_like(num_objf).fill_(
+                default_loss * input_lengths.sum()
+            )
+            frame_match = torch.zeros(B, T, device=input.device, dtype=torch.bool)
+        else:
+            if num_graphs.log_domain:
+                if index_to_pdf is not None:
+                    num_grad = log_probs_grad.to(device=input.device).exp()
+
+                    # index_to_pdf B x U -> B x 1 x U -> B x T x U
+                    input_grad.scatter_add_(
+                        2,
+                        index_to_pdf.unsqueeze(1).expand_as(num_grad),
+                        -num_grad,
+                    )
+                    num_mask = torch.gather(
+                        index_to_pdf,  # B x U
+                        1,
+                        num_grad.argmax(axis=2),  # B x T
+                    )  # B x T
+                else:
+                    num_grad = log_probs_grad.to(device=input.device).exp()
+                    input_grad -= num_grad
+                    num_mask = num_grad.argmax(axis=2)
+            else:
+                num_grad = log_probs_grad
+                input_grad -= num_grad
+                num_mask = num_grad.argmax(axis=2)
+
+            frame_match = (num_mask == den_mask)
+
+        ctx.save_for_backward(input_grad)
+        return loss, input_grad, frame_match
+
+    @staticmethod
+    def backward(ctx, loss_grad, input_grad_grad=None, frame_match_grad=None):
+        input_grad, = ctx.saved_tensors
+        input_grad = torch.mul(input_grad, loss_grad)
+
+        return input_grad, None, None, None, None, None
 
 
 class ChainFunction(torch.autograd.Function):
@@ -25,64 +179,79 @@ class ChainFunction(torch.autograd.Function):
     def forward(ctx, input, input_lengths, graphs, leaky_coefficient):
         exp_input = input.clamp(-30, 30).exp()
         B = input.size(0)
+        T = input.size(1)
         if B != graphs.batch_size:
             raise ValueError("input batch size {0} does not equal to graph batch size {1}"
                              .format(B, graphs.batch_size))
-        forward_transitions = graphs.forward_transitions
-        forward_transition_indices = graphs.forward_transition_indices
-        forward_transition_probs = graphs.forward_transition_probs
-        backward_transitions = graphs.backward_transitions
-        backward_transition_indices = graphs.backward_transition_indices
-        backward_transition_probs = graphs.backward_transition_probs
-        leaky_probs = graphs.leaky_probs
-        num_states = graphs.num_states
-        final_probs = graphs.final_probs
-        start_state = graphs.start_state
-        leaky_coefficient = leaky_coefficient
         packed_data = torch.nn.utils.rnn.pack_padded_sequence(
             input, input_lengths, batch_first=True)
         batch_sizes = packed_data.batch_sizes
         input_lengths = input_lengths.cpu()
-        objf, input_grad, _ = pychain_C.forward_backward(
-            forward_transitions,
-            forward_transition_indices,
-            forward_transition_probs,
-            backward_transitions,
-            backward_transition_indices,
-            backward_transition_probs,
-            leaky_probs, final_probs,
-            start_state,
-            exp_input,
-            batch_sizes,
-            input_lengths,
-            num_states,
-            leaky_coefficient)
+
+        index_to_pdf = None
+        if graphs.index_to_pdf is not None:
+            index_to_pdf = graphs.index_to_pdf.to(device=input.device)
+
+        if not graphs.log_domain:
+            objf, input_grad, ok = pychain_C.forward_backward(
+                graphs.forward_transitions,
+                graphs.forward_transition_indices,
+                graphs.forward_transition_probs,
+                graphs.backward_transitions,
+                graphs.backward_transition_indices,
+                graphs.backward_transition_probs,
+                graphs.leaky_probs,
+                graphs.initial_probs,
+                graphs.final_probs,
+                graphs.start_state,
+                exp_input,
+                batch_sizes,
+                input_lengths,
+                graphs.num_states,
+                leaky_coefficient)
+        else:
+            if index_to_pdf is not None:
+                # index_to_pdf B x U -> B x 1 x U -> B x T x U
+                log_probs = torch.gather(
+                    input,
+                    2,
+                    index_to_pdf.unsqueeze(1).expand((-1, T, -1)),
+                )  # B x T x U
+            objf, log_probs_grad, ok = pychain_pytorch_binding.numerator_fb(
+                graphs.forward_transitions,
+                graphs.forward_transition_indices,
+                graphs.forward_transition_probs,
+                graphs.backward_transitions,
+                graphs.backward_transition_indices,
+                graphs.backward_transition_probs,
+                graphs.final_probs,
+                graphs.start_state,
+                log_probs.to(device='cpu')
+                if index_to_pdf is not None
+                else input.to(device='cpu'),
+                batch_sizes,
+                input_lengths,
+                graphs.num_states,
+            )
+            objf = objf.to(device=input.device)
+
+            if index_to_pdf is not None:
+                input_grad = torch.zeros_like(input)
+                # index_to_pdf B x U -> B x 1 x U -> B x T x U
+                input_grad.scatter_add_(
+                    2,
+                    index_to_pdf.unsqueeze(1).expand_as(log_probs_grad),
+                    log_probs_grad.to(device=input.device).exp(),
+                )
+            else:
+                input_grad = log_probs_grad.to(device=input.device).exp()
+
         ctx.save_for_backward(input_grad)
-        return objf
+        return objf, input_grad
 
     @staticmethod
-    def backward(ctx, objf_grad):
+    def backward(ctx, objf_grad, input_grad_grad=None):
         input_grad, = ctx.saved_tensors
         input_grad = torch.mul(input_grad, objf_grad)
+
         return input_grad, None, None, None
-
-
-class ChainLoss(nn.Module):
-    def __init__(self, den_graph, den_leaky_coefficient=1e-5, num_leaky_coefficient=1e-20, avg=True):
-        super(ChainLoss, self).__init__()
-        self.den_graph = den_graph
-        self.avg = avg
-        self.den_leaky_coefficient = den_leaky_coefficient
-        self.num_leaky_coefficient = num_leaky_coefficient
-
-    def forward(self, x, x_lengths, num_graphs):
-        batch_size = x.size(0)
-        den_graphs = ChainGraphBatch(self.den_graph, batch_size)
-        den_objf = ChainFunction.apply(
-            x, x_lengths, den_graphs, self.den_leaky_coefficient)
-        num_objf = ChainFunction.apply(
-            x, x_lengths, num_graphs, self.num_leaky_coefficient)
-        objf = -(num_objf - den_objf)
-        if self.avg:
-            objf = objf / x_lengths.sum()
-        return objf

--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -7,6 +7,7 @@ setup(name='pychain_C',
                                  ['src/pychain.cc',
                                   'src/base.cc',
                                   'src/chain-kernels.cu',
-                                  'src/chain-computation.cc'],
+                                  'src/chain-computation.cc',
+                                  'src/chain-numerator-computation.cc'],
                                  include_dirs=['src'])],
       cmdclass={'build_ext': BuildExtension})

--- a/pytorch_binding/src/base.h
+++ b/pytorch_binding/src/base.h
@@ -1,7 +1,39 @@
 #ifndef BASE_H_
 #define BASE_H_
 
+#include<cmath>
+
 #define CU1DBLOCK   256
+
+#ifndef FLT_EPSILON
+#define FLT_EPSILON 1.19209290e-7f
+#endif
+
+static const float kMinLogDiffFloat = std::log(FLT_EPSILON);  // negative!
+
+inline float LogAdd(float x, float y) {
+   float diff;
+
+   if (x < y) {
+     diff = x - y;
+     x = y;
+   } else {
+     diff = y - x;
+   }
+   // diff is negative.  x is now the larger one.
+
+   if (diff >= kMinLogDiffFloat) {
+     float res;
+     res = x + std::log1p(std::exp(diff));
+     return res;
+   } else {
+     return x;  // return the larger one.
+   }
+}
+
+inline float Exp(float x) {
+  return std::exp(x);
+}
 
 extern int g_verbose_level;
 

--- a/pytorch_binding/src/chain-computation.h
+++ b/pytorch_binding/src/chain-computation.h
@@ -170,6 +170,7 @@ class ChainComputation {
     torch::Tensor backward_transition_indices,
     torch::Tensor backward_transition_probs,
     torch::Tensor leaky_probs,
+    torch::Tensor initial_probs,
     torch::Tensor final_probs,
     torch::Tensor start_state,
     torch::Tensor exp_nnet_output,
@@ -240,10 +241,11 @@ class ChainComputation {
   torch::Tensor backward_transition_indices_;
   torch::Tensor backward_transition_probs_;
   torch::Tensor leaky_probs_;
+  torch::Tensor initial_probs_;
   // Dimension is (num_sequences, num-hmm-states).
   torch::Tensor final_probs_;
   torch::Tensor start_state_;
-  
+
   // The exp() of the nnet output (the exp() avoids us having to
   // exponentiate in the forward-backward).
   torch::Tensor exp_nnet_output_;
@@ -253,7 +255,7 @@ class ChainComputation {
 
   // sequence_length (i.e. num of frames) of each sequence
   torch::Tensor sequence_lengths_;
-  
+
   // the derivs w.r.t. the nnet outputs
   torch::Tensor nnet_output_deriv_;
 
@@ -277,6 +279,6 @@ class ChainComputation {
 
   // do computation on cuda or not
   bool cuda_;
-  
+
   bool ok_;
 };

--- a/pytorch_binding/src/chain-numerator-computation.cc
+++ b/pytorch_binding/src/chain-numerator-computation.cc
@@ -1,0 +1,299 @@
+// chain-numerator-computation.cc
+
+// Copyright      2015   Johns Hopkins University (author: Daniel Povey)
+//                2019   Yiwen Shao
+//                2020   Yiming Wang
+//                2020   Facebook Inc.  (author: Vimal Manohar)
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+#include "chain-numerator-computation.h"
+#include "base.h"
+
+ChainNumeratorComputation::ChainNumeratorComputation(
+    torch::Tensor forward_transitions,
+    torch::Tensor forward_transition_indices,
+    torch::Tensor forward_transition_probs,
+    torch::Tensor backward_transitions,
+    torch::Tensor backward_transition_indices,
+    torch::Tensor backward_transition_probs,
+    torch::Tensor final_probs,
+    torch::Tensor start_state,
+    torch::Tensor nnet_output,
+    torch::Tensor batch_sizes,
+    torch::Tensor sequence_lengths,
+    int num_states) {
+
+  num_sequences_ = nnet_output.size(0);
+  num_states_ = num_states;
+  num_pdfs_ = nnet_output.size(2);
+  num_frames_ = nnet_output.size(1);
+  num_transitions_ = forward_transitions.size(1);
+
+  forward_transitions_ = forward_transitions;
+  forward_transition_indices_ = forward_transition_indices;
+  forward_transition_probs_ = forward_transition_probs;
+  backward_transitions_ = backward_transitions;
+  backward_transition_indices_ = backward_transition_indices;
+  backward_transition_probs_ = backward_transition_probs;
+  final_probs_ = final_probs;
+  start_state_ = start_state;
+
+  nnet_output_deriv_ = torch::empty_like(nnet_output).fill_(
+    -std::numeric_limits<float>::infinity());
+  nnet_output_ = nnet_output;
+  batch_sizes_ = batch_sizes;
+  sequence_lengths_ = sequence_lengths;
+
+  alpha_ = torch::empty({num_sequences_, num_frames_ + 1, num_states_ + 1}, torch::kFloat).fill_(
+    -std::numeric_limits<float>::infinity());
+  beta_ = torch::empty({num_sequences_, 2, num_states_}, torch::kFloat).fill_(
+    -std::numeric_limits<float>::infinity());
+  tot_log_prob_ = torch::empty({num_sequences_}, torch::kFloat).fill_(
+    -std::numeric_limits<float>::infinity());
+}
+
+void ChainNumeratorComputation::AlphaFirstFrame() {
+  auto alpha_initial_state = alpha_.narrow(1, 0, 1).narrow(2, 0, num_states_).squeeze(1); // B x H
+  alpha_initial_state.scatter_(1, start_state_.unsqueeze(1), 0.0);   // Set initial log-prob to Log(1.0)
+
+  // For alpha-sum
+  alpha_.narrow(1, 0, 1).narrow(2, num_states_, 1).fill_(0.0);
+
+  if (GetVerboseLevel() >= 3)
+    std::cerr << "alpha initial = " << alpha_initial_state;
+}
+
+// the alpha computation for some 0 < t <= num_time_steps_.
+void ChainNumeratorComputation::AlphaRemainingFrames() {
+  int num_hmm_states = num_states_,
+    num_frames = num_frames_,
+    num_pdfs = num_pdfs_,
+    num_transitions = num_transitions_;
+  auto batch_sizes_a = batch_sizes_.accessor<long, 1>();
+
+  auto transition_indices_a = backward_transition_indices_.accessor<int, 3>();
+  auto transitions_a = backward_transitions_.accessor<int, 3>();
+  auto transition_probs_a = backward_transition_probs_.accessor<float, 2>();
+  for (int t = 1; t <= num_frames_; t++) {
+    long num_sequences = batch_sizes_a[t - 1];
+
+    torch::Tensor alpha_t = alpha_.narrow(0, 0, num_sequences)
+                                .narrow(1, t, 1)
+                                .narrow(2, 0, num_hmm_states)
+                                .squeeze(1); // B x H
+    torch::Tensor alpha_tm1 = alpha_.narrow(0, 0, num_sequences)
+                                  .narrow(1, t - 1, 1)
+                                  .narrow(2, 0, num_hmm_states)
+                                  .squeeze(1); // B x H
+
+    // 'probs' is the matrix of pseudo-log-likelihoods for frame t - 1.
+    torch::Tensor probs = nnet_output_.narrow(1, t - 1, 1).squeeze(1);  // B x V
+
+    auto probs_a = probs.accessor<float, 2>();
+    auto alpha_t_a = alpha_t.accessor<float, 2>();
+    auto alpha_tm1_a = alpha_tm1.accessor<float, 2>();
+
+    for (int s = 0; s < num_sequences; s++) {
+      for (int h = 0; h < num_hmm_states; h++) {
+        float this_tot_alpha = 0.0;
+        for (int trans_i = transition_indices_a[s][h][0];
+            trans_i != transition_indices_a[s][h][1]; trans_i++) {
+          float transition_prob = transition_probs_a[s][trans_i];
+          int pdf_id = transitions_a[s][trans_i][2],
+              prev_hmm_state = transitions_a[s][trans_i][0];
+          float prob = probs_a[s][pdf_id],
+              this_prev_alpha = alpha_tm1_a[s][prev_hmm_state];
+          alpha_t_a[s][h] = LogAdd(alpha_t_a[s][h],
+            this_prev_alpha + transition_prob + prob);
+        }
+      }
+    }
+
+    // Add arbitrary scales i.e. Log(1 / prev alpha-sum)
+    // to keep everything small and in good range
+    torch::Tensor prev_alpha_sums = alpha_.narrow(0, 0, num_sequences)
+                                        .narrow(1, t - 1, 1)
+                                        .narrow(2, num_hmm_states, 1)
+                                        .squeeze(1); // B x 1
+    alpha_t.add_(-prev_alpha_sums.expand_as(alpha_t));  // B x H
+
+    // Compute alpha-sum to use as arbitrary scale
+    torch::Tensor this_alpha_sums = alpha_.narrow(0, 0, num_sequences)
+                                   .narrow(1, t, 1)
+                                   .narrow(2, num_hmm_states, 1)
+                                   .squeeze(2)
+                                   .squeeze(1); // B
+    this_alpha_sums.copy_(alpha_t.logsumexp(1)); // B
+
+    if (GetVerboseLevel() >= 3) {
+      std::cerr << "alpha @" << t << " = " << alpha_t;
+      std::cerr << "alpha-sum @" << t << " = " << this_alpha_sums;
+    }
+  }
+}
+
+torch::Tensor ChainNumeratorComputation::Forward() {
+  AlphaFirstFrame();
+  AlphaRemainingFrames();
+  auto obj = ComputeTotLogLike();
+  return obj;
+}
+
+torch::Tensor ChainNumeratorComputation::ComputeTotLogLike() {
+  auto sequence_lengths_a = sequence_lengths_.accessor<int, 1>();
+  if (GetVerboseLevel() >= 3)
+    std::cerr << "final probs = " << final_probs_;
+  for (int s = 0; s < num_sequences_; s++) {
+    int sequence_length = sequence_lengths_a[s];
+    torch::Tensor last_frame_alpha = alpha_.narrow(0, s, 1)
+      .narrow(1, sequence_length, 1)
+      .narrow(2, 0, num_states_).squeeze(1).squeeze(0); // H
+    if (GetVerboseLevel() >= 3)
+      std::cerr << "last frame alpha for sequence "
+                << s << " = " << last_frame_alpha << std::endl;
+    torch::Tensor this_final_probs =
+        final_probs_.narrow(0, s, 1).squeeze(0); // H
+    torch::Tensor last_frame_alpha_sum =
+        last_frame_alpha.add(this_final_probs).logsumexp(0); // 1
+    if (GetVerboseLevel() >= 3)
+      std::cerr << "last frame alpha sum for sequence "
+                << s << " = " << last_frame_alpha_sum << std::endl;
+    torch::Tensor alpha_frame_sum = alpha_.narrow(0, s, 1)
+      .narrow(1, 0, sequence_length)
+      .narrow(2, num_states_, 1).squeeze(2).squeeze(0); // T
+    if (GetVerboseLevel() >= 3)
+      std::cerr << "alpha frame sums for sequence " << s
+                << " = " << alpha_frame_sum << std::endl;
+    tot_log_prob_.narrow(0, s, 1).copy_(alpha_frame_sum.sum() + last_frame_alpha_sum);
+    if (GetVerboseLevel() >= 3)
+      std::cerr << "tot_log_prob for sequence " << s
+                << " = " << alpha_frame_sum.sum()
+                << " + " << last_frame_alpha_sum
+                << " = " << tot_log_prob_.narrow(0, s, 1);
+  }
+  return tot_log_prob_.sum();
+}
+
+void ChainNumeratorComputation::BetaLastFrame() {
+  auto sequence_lengths_a = sequence_lengths_.accessor<int, 1>();
+  for (int s = 0; s < num_sequences_; s++) {
+    int sequence_length = sequence_lengths_a[s];
+    torch::Tensor last_frame_beta = beta_.narrow(0, s, 1)
+      .narrow(1, sequence_length % 2, 1).squeeze(1).squeeze(0); // H
+    if (GetVerboseLevel() >= 3)
+      std::cerr << "last frame beta for sequence "
+                << s << " = " << last_frame_beta << std::endl;
+    torch::Tensor last_frame_alpha = alpha_.narrow(0, s, 1)
+      .narrow(1, sequence_length, 1)
+      .narrow(2, 0, num_states_).squeeze(1).squeeze(0); // H
+    if (GetVerboseLevel() >= 3)
+      std::cerr << "last frame alpha dash for sequence "
+                << s << " = " << last_frame_alpha << std::endl;
+    torch::Tensor this_final_probs = final_probs_.narrow(0, s, 1).squeeze(0); // H
+    torch::Tensor tot_prob = last_frame_alpha.add(this_final_probs).logsumexp(0); // 1
+    last_frame_beta.copy_(this_final_probs);
+    last_frame_beta.add_(-tot_prob);
+    if (GetVerboseLevel() >= 3)
+      std::cerr << "beta @ last-frame for " << s << " = "
+                << last_frame_beta << std::endl;
+  }
+}
+
+void ChainNumeratorComputation::BetaRemainingFrames() {
+  auto batch_sizes_a = batch_sizes_.accessor<long, 1>();
+  int num_hmm_states = num_states_,
+    num_frames = num_frames_,
+    num_pdfs = num_pdfs_,
+    num_transitions = num_transitions_;
+
+  auto transition_indices_a = forward_transition_indices_.accessor<int, 3>();
+  auto transitions_a = forward_transitions_.accessor<int, 3>();
+  auto transition_probs_a = forward_transition_probs_.accessor<float, 2>();
+
+  for (int t = num_frames - 1; t >= 0; t--) {
+    long num_sequences = batch_sizes_a[t];
+
+    // B x (H + 1)
+    torch::Tensor alpha_t = alpha_.narrow(1, t, 1).squeeze(1),
+      beta_tp1 = beta_.narrow(1, (t + 1) % 2, 1).squeeze(1),
+      beta_t = beta_.narrow(1, t % 2, 1).squeeze(1);
+    // 'probs' is the matrix of pseudo-likelihoods for frame t.
+    torch::Tensor probs = nnet_output_.narrow(1, t, 1).squeeze(1);  // B x V
+    torch::Tensor log_prob_deriv = nnet_output_deriv_.narrow(1, t, 1).squeeze(1);  // B x V
+
+    auto probs_a = probs.accessor<float, 2>();
+    auto log_prob_deriv_a = log_prob_deriv.accessor<float, 2>();
+    auto alpha_t_a = alpha_t.accessor<float, 2>();
+    auto beta_t_a = beta_t.accessor<float, 2>();
+    auto beta_tp1_a = beta_tp1.accessor<float, 2>();
+
+    for (int s = 0; s < num_sequences; s++) {
+      for (int h = 0; h < num_hmm_states; h++) {
+        float this_alpha_prob = alpha_t_a[s][h],
+            inv_arbitrary_scale = alpha_t_a[s][num_hmm_states];
+        float tot_variable_factor = -std::numeric_limits<float>::infinity();
+        for (int trans_i = transition_indices_a[s][h][0];
+            trans_i != transition_indices_a[s][h][1]; trans_i++) {
+          float transition_prob = transition_probs_a[s][trans_i];
+          int pdf_id = transitions_a[s][trans_i][2],
+              next_hmm_state = transitions_a[s][trans_i][1];
+          float variable_factor = transition_prob +
+              beta_tp1_a[s][next_hmm_state] +
+              probs_a[s][pdf_id] - inv_arbitrary_scale;
+          tot_variable_factor = LogAdd(tot_variable_factor, variable_factor);
+          float occupation_prob = variable_factor + this_alpha_prob;
+          log_prob_deriv_a[s][pdf_id] = LogAdd(log_prob_deriv_a[s][pdf_id],
+                                               occupation_prob);
+          //log_prob_deriv_a[s][pdf_id] += Exp(occupation_prob);
+        }
+        beta_t_a[s][h] = tot_variable_factor;
+      }
+    }
+
+    if (GetVerboseLevel() >= 3)
+      std::cerr << "beta @ " << t << " = " << beta_t << std::endl;
+  }
+}
+
+bool ChainNumeratorComputation::Backward() {
+  BetaLastFrame();
+  BetaRemainingFrames();
+  return CheckValues();
+}
+
+bool ChainNumeratorComputation::CheckValues() {
+  auto sequence_lengths_a = sequence_lengths_.accessor<int, 1>();
+  for (int s = 0; s < num_sequences_; s++) {
+    int sequence_length = sequence_lengths_a[s];
+    std::vector<int> times = {sequence_length - 1, 0};
+
+    for (const int t : times) {
+      torch::Tensor log_prob_deriv = nnet_output_deriv_
+          .narrow(0, s, 1).narrow(1, t, 1).squeeze(1).squeeze(0); // V
+      float deriv_sum = log_prob_deriv.exp().sum().cpu().data<float>()[0];
+
+      if (!ApproxEqual(deriv_sum, 1.0)) {
+        std::cerr << "On time " << t << " for seq " << s << ", deriv sum "
+                  << deriv_sum << " != 1.0" << std::endl;
+        if (fabs(deriv_sum - 1.0) > 0.05 || deriv_sum - deriv_sum != 0) {
+          std::cerr << "Excessive error detected, will abandon this minibatch"
+                    << std::endl;
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}

--- a/pytorch_binding/src/chain-numerator-computation.h
+++ b/pytorch_binding/src/chain-numerator-computation.h
@@ -1,0 +1,241 @@
+// chain-numerator-computation.h
+
+// Copyright       2015  Johns Hopkins University (Author: Daniel Povey)
+//                 2019  Yiwen Shao
+//                 2020  Yiming Wang
+//                 2020  Facebook Inc.  (Author: Vimal Manohar)
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <vector>
+#include <map>
+#include <torch/extension.h>  // @manual=//caffe2:torch_extension
+
+/*
+  This extended comment describes how we implement forward-backward without log
+  and without overflow, and also the leaky-HMM idea.
+  We'll start by establishing the notation for conventional forward-backward,
+  then add the 'arbitrary-scale' concept that prevents overflow, and then
+  add the 'leaky-hmm' concept.
+  All this is done in parallel over multiple sequences, but the computations
+  are independent over the separate sequences, so we won't introduce any notation
+  or index for the sequence; we'll just explain it for one sequence.
+  Suppose we have I hmm-states, numbered i = 0 ... I-1 (we'll use i and j for
+  hmm-state indexes).  Let foll(i) give a list of arcs leaving state i, and
+  pred(i) give a list of arcs entering state i, and we'll use notation like:
+    for (j, p, n) in foll(i):
+  for iterating over those arcs, where in this case j is the destination-state,
+  p is the transition-probability of the arc and n is the pdf-id index.
+  We can then look up the emission probability as x(t, n) for some frame
+  0 <= t < T.
+  ** Version 1 of the computation (naive version) **
+  * Forward computation (version 1)
+  In the forward computation we're computing alpha(i, t) for 0 <= t <= T):
+    - For the first frame, set alpha(0, i) = init(i), where init(i) is the
+      initial-probabilitiy from state i.  # in our framework these are obtained
+      #  by running the HMM for a while and getting an averaged occupation
+      # probability, and using this as an initial-prob, since the boundaries of
+      # chunks don't really correspond to utterance boundaries in general.]
+    - For t = 1 ... T:
+        for i = 0 ... I-1:
+           alpha(t, i) = 0
+           for (j, p, n) in pred(i):  # note: j is preceding-state.
+              alpha(t, i) += x(t-1, n) * alpha(t-1, j) * p.
+    - total-prob = \sum_i alpha(T, i) * final_probs(i). # note, we take the final-probs
+                                                        # of all states to be 1.0 for
+                                                        # denominator computeation.
+  * Backward computation (version 1)
+  And now for the backward computation.  Contrary to tradition, we include the
+  inverse of the total-prob as a factor in the betas.  This is both more
+  convenient (it simplifies the way we obtain posteriors), and makes the
+  algorithm more generalizable as all the beta quantities can be interpreted as
+  the partial derivative of the overall logprob with respect to their
+  corresponding alpha.
+  In forward backward notation, gamma is normally used for state-level
+  occupation probabilities, but what we care about here is pdf-id-level
+  occupation probabilities (i.e. the partial derivative of the overall logprob
+  w.r.t. the logs of the x(t, n) quantities), so we use gamma for that.
+    - for the final frame:
+       for each i, beta(T, i) = final_probs(i) / total-prob.
+    - for t = T-1 ... 0:
+        for i = 0 ... I-1:
+           beta(t, i) = 0
+           for (j, p, n) in foll(i):  # note: j is following-state.
+              beta(t, i) += x(t, n) * beta(t+1, j) * p.
+              gamma(t, n) += alpha(t, i) * x(t, n) * beta(t+1, j) * p.
+  ** Version 2 of the computation (renormalized version) **
+  Version 1 of the algorithm is susceptible to numeric underflow and overflow,
+  due to the limited range of IEEE floating-point exponents.
+  Define tot-alpha(t) = \sum_i alpha(t, i).  Then the renormalized version of
+  the computation is as above, except whenever the quantity x(t, n) appears,
+  we replace it with x(t, n) / tot-alpha(t).  In the algorithm we refer to
+  1.0 / tot-alpha(t) as 'arbitrary_scale', because mathematically we can use any
+  value here as long as we are consistent and the value only varies with t
+  and not with n; we'll always get the same posteriors (gamma).
+  When the algorithm outputs log(total-prob) as the total log-probability
+  of the HMM, we have to instead return the expression:
+    log(total-prob) + \sum_{t=0}^{T-1} \log tot-alpha(t).
+  to correct for the scaling of the x values.
+  The algorithm is still vulnerable to overflow in the beta computation because
+  it's possible that the dominant path could have a very tiny alpha.  However,
+  once we introduce the leaky-HMM idea (below), this problem will disappear.
+  ** Version 3 of the computation (leaky-HMM version) **
+  The leaky-HMM idea is intended to improve generalization by allowing paths
+  other than those explicitly allowed by the FST we compiled.  Another way to
+  look at it is as a way of hedging our bets about where we split the utterance,
+  so it's as we're marginalizing over different splits of the utterance.  You
+  could also think of it as a modification of the FST so that there is an
+  epsilon transition from each state to a newly added state, with probability
+  one, and then an epsilon transition from the newly added state to each state
+  with probability leaky-hmm-prob * init(i) [except we need a mechanism so that
+  no more than two epsilon transitions can be taken per frame- this would involve
+  creating two copies of the states]
+  Recall that we mentioned that init(i) is the initial-probability of
+  HMM-state i, but these are obtained in such a way that they can be treated
+  as priors, or average occupation-probabilities.
+  Anyway, the way we formulate leaky-hmm is as follows:
+  * Forward computation (version 3)
+  Let leaky-hmm-prob be a constant defined by the user, with 0.1 being a typical
+  value.  It defines how much probability we give to the 'leaky' transitions.
+  - For frame 0, set alpha(0, i) = init(i).
+  - For 0 <= t <= T, define tot-alpha(t) = \sum_i alpha(t, i).
+  - For 0 <= t <= T, define alpha'(t, i) = alpha(t, i) + tot-alpha(t) * leaky-hmm-prob * init(i).
+  - For 1 <= t <= T, the computation of alpha(t, i) is as before except we use
+      the previous frame's alpha' instead of alpha.  That is:
+           alpha(t, i) = 0
+           for (j, p, n) in pred(i):  # note: j is preceding-state.
+              alpha(t, i) += alpha'(t-1, j) * p * x(t-1, n) / tot-alpha(t-1)
+  - total-prob = \sum_i alpha'(T, i)
+  The corrected log-prob that we return from the algorithm will be
+   (total-prob + \sum_{t=0}^{T-1} \log tot-alpha(t)).
+  * Backward computation (version 3)
+  The backward computation is as follows.  It is fairly straightforward to
+  derive if you think of it as an instance of backprop where beta, tot-beta and
+  beta' are the partial derivatives of the output log-prob w.r.t. the
+  corresponding alpha, tot-alpha and alpha' quantities.  Note, tot-beta is not
+  really the sum of the betas as its name might suggest, it's just the
+  derivative w.r.t. tot-alpha.
+   - beta'(T, i) = 1 / total-prob.
+   - for 0 <= t <= T, define tot-beta(t) = leaky-hmm-prob * \sum_i init(i) * beta'(t, i)
+   - for 0 <= t <= T, define beta(t, i) = beta'(t, i) + tot-beta(t).
+   - for 0 <= t < T, we compute beta'(t, i) and update gamma(t, n) as follows:
+        for 0 <= i < I:
+           beta'(t, i) = 0
+           for (j, p, n) in foll(i):  # note: j is following-state.
+              beta'(t, i) += beta(t+1, j) * p * x(t, n) / tot-alpha(t)
+              gamma(t, n) += alpha'(t, i) * beta(t+1, j) * p *  x(t, n) / tot-alpha(t)
+   Note: in the code, the tot-alpha and tot-beta quantities go in the same
+   memory location that the corresponding alpha and beta for state I would go.
+ */
+
+// This does forward-backward in parallel on a number of sequences, using a
+// single HMM.
+class ChainNumeratorComputation {
+ public:
+  //  Constructor
+  ChainNumeratorComputation(
+    torch::Tensor forward_transitions,
+    torch::Tensor forward_transition_indices,
+    torch::Tensor forward_transition_probs,
+    torch::Tensor backward_transitions,
+    torch::Tensor backward_transition_indices,
+    torch::Tensor backward_transition_probs,
+    torch::Tensor final_probs,
+    torch::Tensor start_state,
+    torch::Tensor nnet_output,
+    torch::Tensor batch_sizes,
+    torch::Tensor sequence_lengths,
+    int num_states);
+
+  // Does the forward computation, and returns the total log-like summed over
+  // all sequences.  You will have to scale this by any supervision weighting
+  // factor, manually.  Note: this log-like will be negated before it
+  // is added into the objective function, since this is the denominator
+  // computation.
+  torch::Tensor Forward();
+
+  torch::Tensor GetNnetGrad() {return nnet_output_deriv_;}
+
+  // this adds the derivative of the log-prob w.r.t. the
+  // nnet output to 'nnet_output_deriv'.
+  // returns true if everything seemed OK, false if a failure was detected.
+  bool Backward();
+
+ private:
+  // sets up the alpha for frame t = 0.
+  void AlphaFirstFrame();
+  // the alpha computation for some 0 < t <= num_time_steps_.
+  void AlphaRemainingFrames();
+
+  // done after all the alphas, this function computes and returns the total
+  // log-likelihood summed over all the sequences
+  torch::Tensor ComputeTotLogLike();
+
+  // sets up the beta for frame t = T.
+  void BetaLastFrame();
+  // beta computation for 0 <= t < num_time_steps_.
+  void BetaRemainingFrames();
+
+  // Returns false if a bad problem is detected.
+  bool CheckValues();
+
+  // number of separate frame sequences
+  int num_sequences_;
+  // number of frames per sequence.
+  int num_frames_;
+  // number of hmm states
+  int num_states_;
+  // number of pdf ids
+  int num_pdfs_;
+  // number of transitions
+  int num_transitions_;
+
+  torch::Tensor forward_transitions_;
+  torch::Tensor forward_transition_indices_;
+  torch::Tensor forward_transition_probs_;
+  torch::Tensor backward_transitions_;
+  torch::Tensor backward_transition_indices_;
+  torch::Tensor backward_transition_probs_;
+  // Dimension is (num_sequences, num-hmm-states).
+  torch::Tensor final_probs_;
+  torch::Tensor start_state_;
+
+  // The nnet output
+  torch::Tensor nnet_output_;
+
+  // batch size of each time step
+  torch::Tensor batch_sizes_;
+
+  // sequence_length (i.e. num of frames) of each sequence
+  torch::Tensor sequence_lengths_;
+
+  // the derivs w.r.t. the nnet outputs
+  torch::Tensor nnet_output_deriv_;
+
+  // the (temporarily) alpha and (more permanently) alpha-dash probabilities;
+  // dimension is (num-sequences, frames_per_sequence + 1, num-hmm-states + 1)
+  // Note, they are not logs. alpha_[:, :, -1]
+  // are for the alpha-sums.
+  torch::Tensor alpha_;
+
+  // the beta (also beta-dash) probabilities (rolling buffer) for the backward
+  // algorithm. Dimension is (num_sequences, 2, num-hmm-states).
+  // Note: for efficiency and to simplify the equations, these are actually the
+  // beta / tot_prob_.
+  torch::Tensor beta_;
+
+  // the log of tot_prob_.
+  torch::Tensor tot_log_prob_;
+};

--- a/pytorch_binding/src/pychain.cc
+++ b/pytorch_binding/src/pychain.cc
@@ -18,6 +18,7 @@
 #include <torch/extension.h>
 #include <math.h>
 #include "chain-computation.h"
+#include "pychain_numerator_computation.h"
 #include "base.h"
 
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
@@ -30,6 +31,7 @@ std::vector<torch::Tensor> ForwardBackward(
     torch::Tensor backward_transition_indices,
     torch::Tensor backward_transition_probs,
     torch::Tensor leaky_probs,
+    torch::Tensor initial_probs,
     torch::Tensor final_probs,
     torch::Tensor start_state,
     torch::Tensor exp_nnet_output,
@@ -49,7 +51,7 @@ std::vector<torch::Tensor> ForwardBackward(
   CHECK_CONTIGUOUS(sequence_lengths);
   CHECK_CONTIGUOUS(final_probs);
   CHECK_CONTIGUOUS(start_state);
-  
+
   ChainComputation chain(
       forward_transitions,
       forward_transition_indices,
@@ -58,6 +60,7 @@ std::vector<torch::Tensor> ForwardBackward(
       backward_transition_indices,
       backward_transition_probs,
       leaky_probs,
+      initial_probs,
       final_probs,
       start_state,
       exp_nnet_output,
@@ -65,15 +68,64 @@ std::vector<torch::Tensor> ForwardBackward(
       sequence_lengths,
       num_states,
       leaky_hmm_coefficient);
-  
+
   auto obj = chain.Forward();
-  chain.Backward();
-  auto alpha = chain.GetAlpha();
+  bool ret = chain.Backward();
   auto nnet_output_grad = chain.GetNnetGrad();
-  return {obj, nnet_output_grad, alpha};
+  torch::Tensor ok = torch::zeros({1}, torch::kBool).fill_(ret);
+
+  return {obj, nnet_output_grad, ok};
+}
+
+std::vector<torch::Tensor> NumeratorFB(
+    torch::Tensor forward_transitions,
+    torch::Tensor forward_transition_indices,
+    torch::Tensor forward_transition_probs,
+    torch::Tensor backward_transitions,
+    torch::Tensor backward_transition_indices,
+    torch::Tensor backward_transition_probs,
+    torch::Tensor final_probs,
+    torch::Tensor start_state,
+    torch::Tensor nnet_output,
+    torch::Tensor batch_sizes,
+    torch::Tensor sequence_lengths,
+    int num_states) {
+  CHECK_CONTIGUOUS(forward_transitions);
+  CHECK_CONTIGUOUS(forward_transition_indices);
+  CHECK_CONTIGUOUS(forward_transition_probs);
+  CHECK_CONTIGUOUS(backward_transitions);
+  CHECK_CONTIGUOUS(backward_transition_indices);
+  CHECK_CONTIGUOUS(backward_transition_probs);
+  CHECK_CONTIGUOUS(nnet_output);
+  CHECK_CONTIGUOUS(batch_sizes);
+  CHECK_CONTIGUOUS(sequence_lengths);
+  CHECK_CONTIGUOUS(final_probs);
+  CHECK_CONTIGUOUS(start_state);
+
+  ChainNumeratorComputation chain(
+      forward_transitions,
+      forward_transition_indices,
+      forward_transition_probs,
+      backward_transitions,
+      backward_transition_indices,
+      backward_transition_probs,
+      final_probs,
+      start_state,
+      nnet_output,
+      batch_sizes,
+      sequence_lengths,
+      num_states);
+
+  auto obj = chain.Forward();
+  bool ret = chain.Backward();
+  auto nnet_output_grad = chain.GetNnetGrad();
+  torch::Tensor ok = torch::zeros({1}, torch::kBool).fill_(ret);
+
+  return {obj, nnet_output_grad, ok};
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("forward_backward", &ForwardBackward);
   m.def("set_verbose_level", &SetVerboseLevel);
+  m.def("numerator_fb", &NumeratorFB);
 }


### PR DESCRIPTION
This commit adds 
1. log-domain numerator computation, which avoids underflow and issues of skipping frames due to leaky HMM in numerator.
2. Setting leaky probabilities by running forward-backward on the denominator graph.
3. Copying only specific pdfs per-sequence in the batch to make CPU - GPU transfer efficient during numerator computation.